### PR TITLE
Removed dispatch_release() from EKSemaphore

### DIFF
--- a/EnumeratorKit/EKFiber/EKSemaphore.m
+++ b/EnumeratorKit/EKFiber/EKSemaphore.m
@@ -54,11 +54,4 @@
     return (result == 0);
 }
 
-#pragma mark Deallocation
-
-- (void)dealloc
-{
-    dispatch_release(_semaphore);
-}
-
 @end


### PR DESCRIPTION
As of the iOS 6 SDK, dispatch_\* participates in ARC. See https://github.com/AFNetworking/AFNetworking/pull/517
