### PR TITLE
Update enumerable methods to respect the type of the receiver where possible

### DIFF
--- a/EnumeratorKit.xcodeproj/project.pbxproj
+++ b/EnumeratorKit.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		4AD1308A185C0C3B003E7145 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AD13089185C0C3B003E7145 /* XCTest.framework */; };
 		4AD1308B185C0C3B003E7145 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4AB6FA971740C5AE00DDBAD4 /* Foundation.framework */; };
 		4AD3D59317534ACD0050CE35 /* NSObject+EKEnumerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AD3D59217534ACD0050CE35 /* NSObject+EKEnumerator.m */; };
+		CE26A0971A85B1BA000A4F1B /* EKEnumerableNSArraySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = CE26A0961A85B1BA000A4F1B /* EKEnumerableNSArraySpec.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +106,7 @@
 		4AD3D59417534E8A0050CE35 /* NSObjectAsEKEnumeratorSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSObjectAsEKEnumeratorSpec.m; sourceTree = "<group>"; };
 		8C2FE23C509349279B73E901 /* libPods-Specs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Specs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A3BC90CACB134E8F800CCA89 /* Pods-Specs.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Specs.xcconfig"; path = "Pods/Pods-Specs.xcconfig"; sourceTree = "<group>"; };
+		CE26A0961A85B1BA000A4F1B /* EKEnumerableNSArraySpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EKEnumerableNSArraySpec.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -185,6 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				4AC3BB7A174B6D9100108331 /* EKEnumerableSpec.m */,
+				CE26A0961A85B1BA000A4F1B /* EKEnumerableNSArraySpec.m */,
 				4ACB2E071754184D009AC260 /* EKEnumerableNSDictionarySpec.m */,
 				4ACB2E0C175452EB009AC260 /* EKEnumerableNSSetSpec.m */,
 				4ACB2E11175457AF009AC260 /* EKEnumerableNSOrderedSetSpec.m */,
@@ -402,6 +405,7 @@
 				4A6A09FF185FA4A80053DAE2 /* EKEnumerableNSDictionarySpec.m in Sources */,
 				4A6A0A00185FA4A80053DAE2 /* EKEnumerableNSSetSpec.m in Sources */,
 				4A6A0A01185FA4A80053DAE2 /* EKEnumerableNSOrderedSetSpec.m in Sources */,
+				CE26A0971A85B1BA000A4F1B /* EKEnumerableNSArraySpec.m in Sources */,
 				4A6A0A02185FA4A80053DAE2 /* EKEnumeratorSpec.m in Sources */,
 				4A6A0A03185FA4A80053DAE2 /* EKFiberSpec.m in Sources */,
 				4A6A0A04185FA4A80053DAE2 /* EKSemaphoreSpec.m in Sources */,

--- a/EnumeratorKit/Core/EKEnumerable.h
+++ b/EnumeratorKit/Core/EKEnumerable.h
@@ -379,12 +379,12 @@
  @return A filtered array containing all the objects for which the
     block returned `YES`.
  */
-- (NSArray *)select:(BOOL (^)(id obj))block;
+- (instancetype)select:(BOOL (^)(id obj))block;
 
 /**
  Alias for `select:`.
  */
-- (NSArray *)filter:(BOOL (^)(id obj))block;
+- (instancetype)filter:(BOOL (^)(id obj))block;
 
 /**
  Like `select:`, but instead returns the elements for which the block
@@ -406,7 +406,7 @@
  @return A filtered array containing all the objects for which the
     block returned `NO`.
  */
-- (NSArray *)reject:(BOOL (^)(id obj))block;
+- (instancetype)reject:(BOOL (^)(id obj))block;
 
 /**
  Find the first element in a collection for which the block returns `YES`.

--- a/EnumeratorKit/Core/EKEnumerable.h
+++ b/EnumeratorKit/Core/EKEnumerable.h
@@ -489,7 +489,7 @@
 /** @name Other methods */
 
 /** Take elements from a collection */
-- (NSArray *)take:(NSInteger)number;
+- (instancetype)take:(NSInteger)number;
 
 /** Get an array */
 - (NSArray *)asArray;

--- a/EnumeratorKit/Core/EKEnumerable.h
+++ b/EnumeratorKit/Core/EKEnumerable.h
@@ -18,8 +18,8 @@
 
  2. Implement `+load` and call `[self includeEKEnumerable]`
 
- 3. Implement `-each:` to traverse the collection, applying the block
-    to each element.
+ 3. Implement the required `-each:` and `-initWithEnumerable:` methods in
+    the `EKEnumerable` protocol.
 
  For example:
 
@@ -34,6 +34,11 @@
     + (void)load
     {
         [self includeEKEnumerable];
+    }
+
+    - (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+    {
+        return [self initWithArray:[enumerable asArray]];
     }
 
     - (instancetype)each:(void (^)(id))block
@@ -53,6 +58,17 @@
 #pragma mark - Initialisation
 /** @name Initialisation **/
 
+/**
+ Called by `EnumeratorKit` to initialize a new intance of a collection
+ containing the transformed or filtered results after applying some operation.
+
+ For example, the default implementation of `-map:` calls this initializer and
+ passes in an enumerable containing the mapped values. Your implementation of
+ this method should use the values in the enumerable to initialize the new
+ instance.
+
+ @param enumerable An enumerable containing the values to initialize this instance.
+ */
 - (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable;
 
 #pragma mark - Traversal

--- a/EnumeratorKit/Core/EKEnumerable.h
+++ b/EnumeratorKit/Core/EKEnumerable.h
@@ -100,42 +100,34 @@
 /** @name Transformations */
 
 /**
- Applies the block to each element in the collection, and collects
- the return values in an array. If the block returns `nil`,
- `[NSNull null]` will automatically be inserted into the array.
+ Return a new enumerable with the results of applying `block` to each element
+ in the receiver. `nil` values are automatically boxed as `NSNull`.
 
  Usage:
 
     Animal *dog = [Animal animalWithName:@"Spike"];
     Animal *cat = [Animal animalWithName:@"Princess"];
 
-    [@[dog, cat] map:^(id pet){
-        return [pet name];
+    [@[dog, cat] map:^(Animal *pet){
+        return pet.name;
     }];
     // => @[@"Spike", @"Princess"];
 
  @param block A block that accepts a single object and returns an object.
-
- @return Returns a new array with the results of applying the block to
-    each element in the collection. The resulting array will always
-    have the same count as the receiver.
  */
-- (NSArray *)map:(id (^)(id obj))block;
+- (instancetype)map:(id (^)(id obj))block;
 
 /**
- A combination of `-map:` and `-eachWithIndex:`.
+ Map `block` over each element in the receiver, while passing the index of each element.
 
  @param block A block that accepts an object and an `NSUInteger` index.
-
- @return Returns a new array with the results of applying the block to
-    each element in the collection. The resulting array will always
-    have the same count as the receiver.
  */
-- (NSArray *)mapWithIndex:(id (^)(id obj, NSUInteger i))block;
+- (instancetype)mapWithIndex:(id (^)(id obj, NSUInteger i))block;
 
 /**
- Performs a `map:` with the block, returning a single flattened array
- as the result.
+ Maps `block` over the receiver, combining each enumerable into a single enumerable.
+ `nil` values are automatically converted into an empty enumerable by calling
+ calling `+new` on the receiver's class.
 
  Usage:
 
@@ -144,14 +136,9 @@
      }];
      // => @[@0, @"0", @1, @"1", @2, @"2"]
 
- @param block A block that accepts a single object and returns an
-    object. Returning an array will cause the *contents* of the array to
-    be flattened and added to the result array.
-
- @return A flattened array with the results of applying a `map:` with
-    the block.
+ @param block A block accepting a single object and returning an enumerable.
  */
-- (NSArray *)flattenMap:(id (^)(id obj))block;
+- (instancetype)flattenMap:(id<EKEnumerable> (^)(id obj))block;
 
 /**
  `mapDictionary:` behaves just like `map:` except that it returns an

--- a/EnumeratorKit/Core/EKEnumerable.h
+++ b/EnumeratorKit/Core/EKEnumerable.h
@@ -81,7 +81,7 @@
  Example:
 
     NSArray *greetings = @[@"Hello", @"Hi"];
-    [numbers each:^(id greeting){
+    [numbers each:^(NSString *greeting){
         NSLog(@"%@, world", greeting);
     }];
 
@@ -100,7 +100,7 @@
  Usage:
 
     NSMutableArray *array = [NSMutableArray array];
-    [@[@"peach", @"pear", @"plum"] eachWithIndex:^(id fruit, NSUInteger i){
+    [@[@"peach", @"pear", @"plum"] eachWithIndex:^(NSString *fruit, NSUInteger i){
         [array addObject:[NSString stringWithFormat:@"%d: %@", i, fruit]];
     }];
     // => @[@"0: peach", @"1: pear", @"2: plum"]
@@ -147,8 +147,8 @@
 
  Usage:
 
-     [@[@0, @1, @2] flattenMap:^(id i){
-         return @[i, [i stringValue]];
+     [@[@0, @1, @2] flattenMap:^(NSNumber *i){
+         return @[i, i.stringValue];
      }];
      // => @[@0, @"0", @1, @"1", @2, @"2"]
 
@@ -165,7 +165,7 @@
     NSDictionary *apple = @{ @"id": @1, @"name": @"Apple", @"grows_on": @"tree" };
     NSDictionary *grape = @{ @"id": @2, @"name": @"Grape", @"grows_on": @"vine" };
 
-    NSDictionary *fruits = [@[banana, apple] mapDictionary:^(id fruit){
+    NSDictionary *fruits = [@[banana, apple] mapDictionary:^(NSDictionary *fruit){
         return @{ fruit[@"name"]: fruit };
     }];
 
@@ -211,8 +211,8 @@
  the item's key. Returns a dictionary of arrays grouped by the set of
  keys returned by the block.
 
-     [@[@3, @1, @2] groupBy:^(id num){
-         if ([num integerValue] % 2 == 0) {
+     [@[@3, @1, @2] groupBy:^(NSNumber *num){
+         if (num.integerValue % 2 == 0) {
              return @"even";
          }
          else {
@@ -239,7 +239,7 @@
  For example, with the array `@[@"foo", @"bar"]`, if we were to chunk by
  each item's first character:
 
-    [@[@"foo", @"bar"] chunk:^(id string){
+    [@[@"foo", @"bar"] chunk:^(NSString *string){
         return [string substringToIndex:1];
     }];
     // => @[
@@ -250,7 +250,7 @@
  Every "chunk" of items that returns the same value from the block is
  grouped together:
 
-    [@[@"foo", @"bar", @"baz"] chunk:^(id string){
+    [@[@"foo", @"bar", @"baz"] chunk:^(NSString *string){
         return [string substringToIndex:1];
     }];
     // => @[
@@ -279,8 +279,8 @@
     NSArray *numbers = @[@5, @1, @100, @13, @28, @123, @321, @10, @99, @4];
 
     // at each step, returns the new maximum
-    [numbers reduce:^(id max, id num){
-        return [num integerValue] > [max integerValue] ? num : max;
+    [numbers reduce:^(NSNumber *max, NSNumber *num){
+        return num.integerValue > max.integerValue ? num : max;
     }];
     // => @321
 
@@ -312,8 +312,8 @@
 
     NSArray *numbers = @[@5, @1, @100, @13, @28, @123, @321, @10, @99, @4];
 
-    [numbers reduce:[numbers take:1] withBlock:^(id maximums, id num){
-        if ([num integerValue] > [[maximums lastObject] integerValue]) {
+    [numbers reduce:[numbers take:1] withBlock:^(NSArray *maximums, NSNumber *num){
+        if (num.integerValue > maximums.lastObject.integerValue) {
             [maximums addObject:num];
         }
         return maximums;
@@ -359,7 +359,7 @@
 
  This is equivalent to the following, using `reduce:`:
 
-    [letters reduce:^(id s, id letter){
+    [letters reduce:^(NSString *s, NSString *letter){
         return [s stringByAppendingString:letter];
     }];
     // => @"Hello"
@@ -384,8 +384,8 @@
 
     - (NSArray *)finishedOperations
     {
-        return [self.operations select:^(id op){
-            return [op isFinished];
+        return [self.operations select:^(NSOperation *op){
+            return op.isFinished;
         }];
     }
 
@@ -411,8 +411,8 @@
 
     - (NSArray *)nonEmptyStrings
     {
-        return [self.strings reject:^(id s){
-            return [s length] == 0;
+        return [self.strings reject:^(NSString *s){
+            return s.length == 0;
         }];
     }
 
@@ -432,8 +432,8 @@
     NSArray *numbers = @[@1, @3, @5, @6, @9];
 
     // look for an even number
-    [numbers find:^BOOL(id obj) {
-        return [obj integerValue] % 2 == 0;
+    [numbers find:^BOOL(NSNumber *number) {
+        return number.integerValue % 2 == 0;
     }];
     // => @6
 
@@ -453,8 +453,8 @@
      NSArray *numbers = @[@1, @3, @5, @7, @9];
 
     // look for an even number
-    [numbers any:^BOOL(id obj) {
-        return [obj integerValue] % 2 == 0;
+    [numbers any:^BOOL(NSNumber *number) {
+        return number.integerValue % 2 == 0;
     }];
     // => @NO
 
@@ -474,8 +474,8 @@
      NSArray *numbers = @[@1, @3, @5, @7, @9];
 
     // Check if all numbers are odd
-    [numbers all:^BOOL(id obj) {
-        return [obj integerValue] % 2 != 0;
+    [numbers all:^BOOL(NSNumber *obj) {
+        return obj.integerValue % 2 != 0;
     }];
     // => @YES
 

--- a/EnumeratorKit/Core/EKEnumerable.h
+++ b/EnumeratorKit/Core/EKEnumerable.h
@@ -50,6 +50,11 @@
 
 @required
 
+#pragma mark - Initialisation
+/** @name Initialisation **/
+
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable;
+
 #pragma mark - Traversal
 /** @name Traversal */
 

--- a/EnumeratorKit/Core/EKEnumerable.h
+++ b/EnumeratorKit/Core/EKEnumerable.h
@@ -141,8 +141,8 @@
 - (instancetype)flattenMap:(id<EKEnumerable> (^)(id obj))block;
 
 /**
- `mapDictionary:` behaves just like `map:` except that it returns an
- `NSDictionary` instead of an `NSArray`.
+ Transform an enumerable into an dictionary by transforming each element into
+ a dictionary entry.
 
  Usage:
 
@@ -163,8 +163,6 @@
 
  @param block A block that maps objects to entries. The dictionary returned
     by this block must not contain more than a single entry.
-
- @return A dictionary containing all the entries returned by the block.
  */
 - (NSDictionary *)mapDictionary:(NSDictionary *(^)(id obj))block;
 
@@ -189,9 +187,6 @@
  values for that key.
 
  @param block A block that returns a unique key for an object.
-
- @return A dictionary with the block's results as keys, mapped to the
-    objects as values.
  */
 - (NSDictionary *)wrap:(id<NSCopying> (^)(id obj))block;
 
@@ -200,7 +195,7 @@
  the item's key. Returns a dictionary of arrays grouped by the set of
  keys returned by the block.
 
-     [@[@3, @1, @2] chunk:^(id num){
+     [@[@3, @1, @2] groupBy:^(id num){
          if ([num integerValue] % 2 == 0) {
              return @"even";
          }

--- a/EnumeratorKit/Core/EKEnumerable.m
+++ b/EnumeratorKit/Core/EKEnumerable.m
@@ -186,31 +186,27 @@
 
 #pragma mark Searching and filtering
 
-- (NSArray *)select:(BOOL (^)(id))block
+- (instancetype)select:(BOOL (^)(id))block
 {
-    NSMutableArray * result = [NSMutableArray array];
+    NSMutableArray *result = [NSMutableArray array];
     [self each:^(id obj) {
         if (block(obj)) {
             [result addObject:obj];
         }
     }];
-    return [result copy];
+    return [[[self class] alloc] initWithEnumerable:result];
 }
 
-- (NSArray *)filter:(BOOL (^)(id))block
+- (instancetype)filter:(BOOL (^)(id))block
 {
     return [self select:block];
 }
 
-- (NSArray *)reject:(BOOL (^)(id))block
+- (instancetype)reject:(BOOL (^)(id))block
 {
-    NSMutableArray * result = [NSMutableArray array];
-    [self each:^(id obj) {
-        if (!block(obj)) {
-            [result addObject:obj];
-        }
+    return [self select:^BOOL(id obj) {
+        return !block(obj);
     }];
-    return [result copy];
 }
 
 

--- a/EnumeratorKit/Core/EKEnumerable.m
+++ b/EnumeratorKit/Core/EKEnumerable.m
@@ -263,7 +263,7 @@
 
 #pragma mark Other methods
 
-- (NSArray *)take:(NSInteger)number
+- (instancetype)take:(NSInteger)number
 {
     NSMutableArray *result = [NSMutableArray array];
     EKEnumerator *e = self.asEnumerator;
@@ -273,12 +273,12 @@
         [result addObject:e.next];
     }
 
-    return result;
+    return [[[self class] alloc] initWithEnumerable:result];
 }
 
 - (NSArray *)asArray
 {
-    return [self take:-1];
+    return [[NSArray alloc] initWithEnumerable:self];
 }
 
 @end

--- a/EnumeratorKit/Core/EKEnumerable.m
+++ b/EnumeratorKit/Core/EKEnumerable.m
@@ -19,6 +19,14 @@
 
 @implementation EKEnumerable
 
+#pragma mark - Initialization
+
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+{
+    NSAssert(NO, @"expected -initWithEnumerable: to be implemented");
+    return nil;
+}
+
 
 #pragma mark - Traversal
 

--- a/EnumeratorKit/Core/EKEnumerator.m
+++ b/EnumeratorKit/Core/EKEnumerator.m
@@ -47,6 +47,11 @@
     return self;
 }
 
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+{
+    return [self initWithObject:enumerable];
+}
+
 + (instancetype)new:(void (^)(id<EKYielder>))block
 {
     return [[self alloc] initWithBlock:block];

--- a/EnumeratorKit/Core/NSArray+EKEnumerable.m
+++ b/EnumeratorKit/Core/NSArray+EKEnumerable.m
@@ -15,6 +15,11 @@
     [self includeEKEnumerable];
 }
 
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+{
+    return [self initWithArray:[enumerable asArray]];
+}
+
 - (id)each:(void (^)(id))block
 {
     [self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {

--- a/EnumeratorKit/Core/NSArray+EKEnumerable.m
+++ b/EnumeratorKit/Core/NSArray+EKEnumerable.m
@@ -17,7 +17,11 @@
 
 - (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
 {
-    return [self initWithArray:[enumerable asArray]];
+    NSMutableArray *array = [NSMutableArray new];
+    [enumerable each:^(id obj) {
+        [array addObject:obj];
+    }];
+    return [self initWithArray:array];
 }
 
 - (id)each:(void (^)(id))block

--- a/EnumeratorKit/Core/NSDictionary+EKEnumerable.m
+++ b/EnumeratorKit/Core/NSDictionary+EKEnumerable.m
@@ -21,13 +21,22 @@
 
     id __block key;
     [enumerable each:^(id obj) {
-        if (key) {
+
+        // first, try to handle enumerables of key-value pairs (as in -eachPair:)
+        if (!key && [NSDictionary ek_isPair:obj]) {
+            [dictionary addEntriesFromDictionary:@{obj[0]: obj[1]}];
+        }
+
+        // otherwise, treat the enumerable as a sequence of keys alternating
+        // with values
+        else if (key) {
             dictionary[key] = obj;
             key = nil;
         }
         else {
             key = obj;
         }
+
     }];
 
     return [self initWithDictionary:dictionary];
@@ -89,6 +98,18 @@
         }];
     }];
     return [[NSDictionary alloc] initWithDictionary:results copyItems:YES];
+}
+
+#pragma mark Private
+
++ (BOOL)ek_isPair:(id)obj
+{
+    if ([obj isKindOfClass:[NSArray class]] && [obj count] == 2) {
+        return YES;
+    }
+    else {
+        return NO;
+    }
 }
 
 @end

--- a/EnumeratorKit/Core/NSDictionary+EKEnumerable.m
+++ b/EnumeratorKit/Core/NSDictionary+EKEnumerable.m
@@ -67,4 +67,28 @@
     return self;
 }
 
+- (instancetype)map:(id (^)(id))block
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary new];
+    [self eachPair:^(id pair) {
+        id mapped = block(pair);
+        dictionary[pair[0]] = mapped;
+    }];
+    return [dictionary copy];
+}
+
+- (instancetype)flattenMap:(id<EKEnumerable> (^)(id))block
+{
+    NSMutableDictionary *results = [NSMutableDictionary new];
+    [self eachPair:^(id pair) {
+        id result = block(pair) ?: [[self class] new];
+        NSAssert([result isKindOfClass:[self class]], @"The block passed to -flattenMap: must return an enumerable of the same type as the receiver.");
+        [result enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+            if (!results[key]) { results[key] = [NSMutableSet new]; }
+            [results[key] addObject:obj];
+        }];
+    }];
+    return [[NSDictionary alloc] initWithDictionary:results copyItems:YES];
+}
+
 @end

--- a/EnumeratorKit/Core/NSDictionary+EKEnumerable.m
+++ b/EnumeratorKit/Core/NSDictionary+EKEnumerable.m
@@ -15,6 +15,24 @@
     [self includeEKEnumerable];
 }
 
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary new];
+
+    id __block key;
+    [enumerable each:^(id obj) {
+        if (key) {
+            dictionary[key] = obj;
+            key = nil;
+        }
+        else {
+            key = obj;
+        }
+    }];
+
+    return [self initWithDictionary:dictionary];
+}
+
 - (instancetype)each:(void (^)(id))block
 {
     return [self eachPair:block];

--- a/EnumeratorKit/Core/NSOrderedSet+EKEnumerable.m
+++ b/EnumeratorKit/Core/NSOrderedSet+EKEnumerable.m
@@ -15,6 +15,11 @@
     [self includeEKEnumerable];
 }
 
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+{
+    return [self initWithArray:[enumerable asArray]];
+}
+
 - (instancetype)each:(void (^)(id))block
 {
     [self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {

--- a/EnumeratorKit/Core/NSSet+EKEnumerable.m
+++ b/EnumeratorKit/Core/NSSet+EKEnumerable.m
@@ -15,6 +15,11 @@
     [self includeEKEnumerable];
 }
 
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+{
+    return [self initWithArray:[enumerable asArray]];
+}
+
 - (instancetype)each:(void (^)(id))block
 {
     [self enumerateObjectsUsingBlock:^(id obj, BOOL *stop) {

--- a/Tests/EKEnumerableNSArraySpec.m
+++ b/Tests/EKEnumerableNSArraySpec.m
@@ -1,0 +1,16 @@
+#import <Kiwi/Kiwi.h>
+#import "NSArray+EKEnumerable.h"
+
+SPEC_BEGIN(EKEnumarbleNSArraySpec)
+
+describe(@"-initWithEnumerable:", ^{
+
+    it(@"it returns an array enumerating the objects in the enumerable", ^{
+        NSOrderedSet *enumerable = [NSOrderedSet orderedSetWithArray:@[@1, @2, @3]];
+        NSArray *array = [[NSArray alloc] initWithEnumerable:enumerable];
+        [[array should] equal:@[@1, @2, @3]];
+    });
+
+});
+
+SPEC_END

--- a/Tests/EKEnumerableNSDictionarySpec.m
+++ b/Tests/EKEnumerableNSDictionarySpec.m
@@ -122,4 +122,16 @@ describe(@"-flattenMap:", ^{
 
 });
 
+describe(@"-select:", ^{
+
+    it(@"returns a new dictionary with only matching entries", ^{
+        NSDictionary *dictionary = @{@"a": @1, @"b": @2};
+        NSDictionary *even = [dictionary select:^BOOL(id pair) {
+            return [pair[1] integerValue] % 2 == 0;
+        }];
+        [[even should] equal:@{@"b": @2}];
+    });
+
+});
+
 SPEC_END

--- a/Tests/EKEnumerableNSDictionarySpec.m
+++ b/Tests/EKEnumerableNSDictionarySpec.m
@@ -87,4 +87,39 @@ describe(@"-eachObject", ^{
 
 });
 
+describe(@"-map:", ^{
+
+    it(@"returns a new dictionary with the receivers values transformed by the block", ^{
+        NSDictionary *dictionary = @{@"a": @1, @"b": @2};
+        NSDictionary *doubled = [dictionary map:^(id pair) {
+            return @([pair[1] integerValue] * 2);
+        }];
+        [[doubled should] equal:@{@"a": @2, @"b": @4}];
+    });
+
+});
+
+describe(@"-flattenMap:", ^{
+
+    it(@"merges the contents of each resulting dictionary, giving the set of values for each key", ^{
+        NSDictionary *people = @{
+            @"person1": @{@"name": @"Steve von Sharp", @"age": @30},
+            @"person2": @{@"name": @"Jess Smith", @"age": @25},
+            @"person3": @{@"name": @"Tristan", @"age": @25},
+        };
+
+        NSDictionary *stats = [people flattenMap:^(id pair) {
+            NSDictionary *person = pair[1];
+            return @{
+                 @"number of names": @([person[@"name"] componentsSeparatedByString:@" "].count),
+                 @"age": person[@"age"],
+            };
+        }];
+
+        [[stats[@"number of names"] should] equal:[NSSet setWithArray:@[@1, @2, @3]]];
+        [[stats[@"age"] should] equal:[NSSet setWithArray:@[@25, @30]]];
+    });
+
+});
+
 SPEC_END

--- a/Tests/EKEnumerableNSDictionarySpec.m
+++ b/Tests/EKEnumerableNSDictionarySpec.m
@@ -3,6 +3,22 @@
 
 SPEC_BEGIN(EKEnumerableNSDictionarySpec)
 
+describe(@"-initWithEnumerable:", ^{
+
+    it(@"constructs a dictionary from alternating keys and values", ^{
+        NSArray *keysAndValues = @[@"foo", @3, @"foobar", @6];
+        NSDictionary *dictionary = [[NSDictionary alloc] initWithEnumerable:keysAndValues];
+        [[dictionary should] equal:@{@"foo": @3, @"foobar": @6}];
+    });
+
+    it(@"ignores a trailing key with no value", ^{
+        NSArray *keysAndValues = @[@"foo", @3, @"foobar"];
+        NSDictionary *dictionary = [[NSDictionary alloc] initWithEnumerable:keysAndValues];
+        [[dictionary should] equal:@{@"foo": @3}];
+    });
+
+});
+
 describe(@"-each", ^{
 
     it(@"enumerates over key-value pairs", ^{

--- a/Tests/EKEnumerableNSOrderedSetSpec.m
+++ b/Tests/EKEnumerableNSOrderedSetSpec.m
@@ -3,6 +3,16 @@
 
 SPEC_BEGIN(EKEnumerableNSOrderedSetSpec)
 
+describe(@"-initWithEnumerable:", ^{
+
+    it(@"constructs an ordered set respecting the order of the enumerable", ^{
+        NSArray *array = @[@2, @1, @3];
+        NSOrderedSet *orderedSet = [[NSOrderedSet alloc] initWithEnumerable:array];
+        [[orderedSet should] equal:[NSOrderedSet orderedSetWithArray:@[@2, @1, @3]]];
+    });
+
+});
+
 describe(@"-each", ^{
 
     __block NSOrderedSet *set;

--- a/Tests/EKEnumerableNSSetSpec.m
+++ b/Tests/EKEnumerableNSSetSpec.m
@@ -3,6 +3,16 @@
 
 SPEC_BEGIN(EKEnumerableNSSetSpec)
 
+describe(@"-initWithEnumerable:", ^{
+
+    it(@"constructs a set containing each enumerated value", ^{
+        NSArray *values = @[@1, @2, @3];
+        NSSet *set = [[NSSet alloc] initWithEnumerable:values];
+        [[set should] equal:[NSSet setWithArray:@[@1, @2, @3]]];
+    });
+
+});
+
 describe(@"-each", ^{
 
     __block NSSet *set;

--- a/Tests/EKEnumerableNSSetSpec.m
+++ b/Tests/EKEnumerableNSSetSpec.m
@@ -30,4 +30,32 @@ describe(@"-each", ^{
 
 });
 
+describe(@"-map:", ^{
+
+    it(@"returns the set of mapped values", ^{
+        NSSet *set = [NSSet setWithArray:@[@"foo", @"bar", @"hello world"]];
+        NSSet *lengths = [set map:^(NSString *s){ return @(s.length); }];
+        [[lengths should] equal:[NSSet setWithArray:@[@3, @11]]];
+    });
+
+});
+
+describe(@"-flattenMap:", ^{
+
+    it(@"returns the union of the resulting sets", ^{
+        NSSet *(^charactersInString)(NSString *) = ^(NSString *s) {
+            NSMutableSet *characters = [NSMutableSet new];
+            for (NSUInteger i = 0; i < s.length; i++) {
+                [characters addObject:[s substringWithRange:NSMakeRange(i, 1)]];
+            }
+            return [characters copy];
+        };
+
+        NSSet *set = [NSSet setWithArray:@[@"foo", @"bar", @"hello world"]];
+        NSSet *alphabet = [set flattenMap:charactersInString];
+        [[alphabet should] equal:[NSSet setWithArray:@[@"f", @"o", @"b", @"a", @"r", @" ", @"h", @"e", @"l", @"w", @"d"]]];
+    });
+
+});
+
 SPEC_END

--- a/Tests/EKEnumerableSpec.m
+++ b/Tests/EKEnumerableSpec.m
@@ -71,7 +71,7 @@ describe(@"-take", ^{
 
         (void)e.next;
         id result = [e take:2];
-        [[result should] equal:@[@1,@2]];
+        [[[result asArray] should] equal:@[@1,@2]];
     });
 
     it(@"returns the whole collection if passed a negative number", ^{

--- a/Tests/EKEnumerableSpec.m
+++ b/Tests/EKEnumerableSpec.m
@@ -98,7 +98,7 @@ describe(@"-asArray", ^{
 
 describe(@"-map", ^{
 
-    it(@"returns an array with the mapped elements", ^{
+    it(@"returns an enumerable with the mapped elements", ^{
         id strings = [@[@1,@2,@3] map:^(id obj){
             return [NSString stringWithFormat:@"%@", obj];
         }];
@@ -115,7 +115,7 @@ describe(@"-map", ^{
 
 describe(@"-mapWithIndex", ^{
 
-    it(@"passes each index to the block and returns the mapped array", ^{
+    it(@"passes each index to the block and returns the new enumerable", ^{
         NSMutableArray *indices = [NSMutableArray new];
         id strings = [@[@10,@11,@12] mapWithIndex:^id(id obj, NSUInteger i) {
             [indices addObject:@(i)];
@@ -129,10 +129,16 @@ describe(@"-mapWithIndex", ^{
 
 describe(@"-flattenMap", ^{
 
-    it(@"returns a new array with the flattened result of applying the block to each item in the array", ^{
+    it(@"returns a new enumerable, flattening the enumerables returned by the block", ^{
         [[[@[@1, @2, @3, @4] flattenMap:^(id e){
             return @[e, @(-[e integerValue])];
         }] should] equal:@[@1, @(-1), @2, @(-2), @3, @(-3), @4, @(-4)]];
+    });
+
+    it(@"handles nil return values", ^{
+        [[[@[@1, @2] flattenMap:^id<EKEnumerable>(id obj) {
+            return nil;
+        }] should] equal:@[]];
     });
 
 });
@@ -148,12 +154,6 @@ describe(@"-mapDictionary", ^{
             @2: @"2",
             @3: @"3"
         }];
-    });
-
-    it(@"raises an exception if the dictionary has more than one entry", ^{
-        [[theBlock(^{
-            [@[@"foo"] mapDictionary:^(id i){ return @{@1: @"1", @2: @"2", @3: @"3"}; }];
-        }) should] raise];
     });
 
     it(@"skips entries that are nil or empty", ^{

--- a/Tests/EKEnumeratorSpec.m
+++ b/Tests/EKEnumeratorSpec.m
@@ -9,13 +9,13 @@ describe(@"-initWithObject", ^{
     it(@"returns an external -each: iterator for enumerable objects", ^{
         EKEnumerator *e = [EKEnumerator enumeratorWithObject:@[@1,@2,@3]];
         id result = [e take:3];
-        [[result should] equal:@[@1,@2,@3]];
+        [[[result asArray] should] equal:@[@1,@2,@3]];
     });
 
     it(@"returns an iterator that yields the object, when passed a regular object", ^{
         EKEnumerator *e = [EKEnumerator enumeratorWithObject:@999];
         id result = [e take:3];
-        [[result should] equal:@[@999]];
+        [[[result asArray] should] equal:@[@999]];
     });
 
 });
@@ -83,7 +83,7 @@ describe(@"infinite enumeration", ^{
         }];
 
         id result = [fib take:10];
-        [[result should] equal:@[ @1, @1, @2, @3, @5, @8, @13, @21, @34, @55 ]];
+        [[[result asArray] should] equal:@[ @1, @1, @2, @3, @5, @8, @13, @21, @34, @55 ]];
     });
 
 });

--- a/Tests/NSObjectIncludeEKEnumerableSpec.m
+++ b/Tests/NSObjectIncludeEKEnumerableSpec.m
@@ -6,9 +6,9 @@
 @end
 
 @implementation EnumerableSubclass
-- (id<EKEnumerable>)map:(id (^)(id))block
+- (instancetype)map:(id (^)(id))block
 {
-    return @[ @"specific implementation" ];
+    return [[[self class] alloc] initWithEnumerable:@[ @"specific implementation" ]];
 }
 @end
 
@@ -25,7 +25,7 @@ describe(@"NSObject+IncludeEKEnumerable", ^{
                 id result = [list map:^id(id obj) {
                     return [NSString stringWithFormat:@"%@", obj];
                 }];
-                [[result should] equal:@[ @"1", @"2" ]];
+                [[result should] equal:[[SortedList alloc] initWithArray:@[ @"1", @"2" ]]];
             });
 
         });
@@ -37,7 +37,7 @@ describe(@"NSObject+IncludeEKEnumerable", ^{
                 id result = [list map:^id(id obj) {
                     return [NSString stringWithFormat:@"%@", obj];
                 }];
-                [[result should] equal:@[ @"specific implementation" ]];
+                [[result should] equal:[[EnumerableSubclass alloc] initWithArray:@[ @"specific implementation" ]]];
             });
 
         });

--- a/Tests/Shared/SortedList.h
+++ b/Tests/Shared/SortedList.h
@@ -11,6 +11,8 @@
 
 @interface SortedList : NSObject <EKEnumerable>
 
+- (instancetype)initWithArray:(NSArray *)array;
+
 - (instancetype)insert:(NSNumber *)object;
 
 @end

--- a/Tests/Shared/SortedList.m
+++ b/Tests/Shared/SortedList.m
@@ -27,6 +27,16 @@
     return self;
 }
 
+- (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
+{
+    if (self = [self init]) {
+        [enumerable each:^(id obj) {
+            [self insert:obj];
+        }];
+    }
+    return self;
+}
+
 - (instancetype)insert:(NSNumber *)object
 {
     [self.data addObject:object];

--- a/Tests/Shared/SortedList.m
+++ b/Tests/Shared/SortedList.m
@@ -19,22 +19,24 @@
     [self includeEKEnumerable];
 }
 
-- (id)init
+- (instancetype)initWithArray:(NSArray *)array
 {
+    NSParameterAssert(array != nil);
+
     if (self = [super init]) {
-        _data = [NSMutableArray array];
+        _data = [[array sortedArrayUsingSelector:@selector(compare:)] mutableCopy];
     }
     return self;
 }
 
+- (id)init
+{
+    return [self initWithArray:@[]];
+}
+
 - (instancetype)initWithEnumerable:(id<EKEnumerable>)enumerable
 {
-    if (self = [self init]) {
-        [enumerable each:^(id obj) {
-            [self insert:obj];
-        }];
-    }
-    return self;
+    return [self initWithArray:[enumerable asArray]];
 }
 
 - (instancetype)insert:(NSNumber *)object
@@ -50,6 +52,26 @@
 {
     [self.data each:block];
     return self;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if ([object isKindOfClass:[SortedList class]]) {
+        return [self isEqualToSortedList:object];
+    }
+    else {
+        return NO;
+    }
+}
+
+- (BOOL)isEqualToSortedList:(SortedList *)sortedList
+{
+    return [self.data isEqualToArray:sortedList.data];
+}
+
+- (NSUInteger)hash
+{
+    return self.data.hash;
 }
 
 @end

--- a/Tests/Shared/SortedList.m
+++ b/Tests/Shared/SortedList.m
@@ -41,6 +41,8 @@
 
 - (instancetype)insert:(NSNumber *)object
 {
+    NSAssert([object respondsToSelector:@selector(compare:)], @"objects in sorted list must be comparable");
+
     [self.data addObject:object];
     [self.data sortUsingComparator:^NSComparisonResult(id obj1, id obj2) {
         return [obj1 compare:obj2];


### PR DESCRIPTION
Initially the goal of this library was to be a straight port of Ruby's Enumerable module. This means that for methods like `-map:` and `-flattenMap:`, Ruby's semantics were also inherited: mapping over a set or dictionary would always return an array instead of something of the same type.

One way to handle these changes would be to implement the methods in question separately for each type. But this loses the arguably nice benefit of getting most of the implementations for free! So here's what I've come up with that allows the generic implementations to be preserved in the majority of cases.