### PR TITLE
Don't copy the umbrella header into every subspec

### DIFF
--- a/EnumeratorKit.podspec
+++ b/EnumeratorKit.podspec
@@ -28,11 +28,11 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |e|
-    e.source_files = 'EnumeratorKit/Core', 'EnumeratorKit/EnumeratorKit.h'
+    e.source_files = 'EnumeratorKit/Core'
     e.dependency 'EnumeratorKit/EKFiber'
   end
 
   s.subspec 'EKFiber' do |f|
-    f.source_files = 'EnumeratorKit/EKFiber', 'EnumeratorKit/EnumeratorKit.h'
+    f.source_files = 'EnumeratorKit/EKFiber'
   end
 end


### PR DESCRIPTION
Fixes the "Multiple build commands for output file..." warning caused by
the umbrella header being copied three different times.